### PR TITLE
Deprecate this repository in favor of modxna/modxna

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # modXNA
-This repository contains the main driver script for modXNA.
+
+**NOTE: THIS REPOSITORY IS NO LONGER BEING UPDATED**
+
+**The current ModXNA GitHub repository can be found here:** https://github.com/modxna/modxna
+
+This repository is an archive of the main driver script for modXNA.
 
 Reference: [Love et. al, "modXNA: A Modular Approach to Parametrization of Modified Nucleic Acids for Use with Amber Force Fields", JCTC, 2024, 20, 21, 9354-9363](https://pubs.acs.org/doi/10.1021/acs.jctc.4c01164)
 


### PR DESCRIPTION
Note that all future updates will be made to https://github.com/modxna/modxna